### PR TITLE
Allow cc.py to run outside of project directory

### DIFF
--- a/cc.py
+++ b/cc.py
@@ -70,7 +70,7 @@ def crawlIndex(domain, index):
 		print('[!] Error reading index')
 		pass
 
-def readIndexFile(index_filename="index.txt"):
+def readIndexFile(index_filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), "index.txt")):
 	global indexes
 	#check when the index file was last updated
 	path = pathlib.Path(index_filename)


### PR DESCRIPTION
Tells the script to look for index.txt in the same directory as cc.py rather than the user's current directory. This allows cc.py to function as expected when calling it from other directories.