### PR TITLE
process all pages in each index when year is specified

### DIFF
--- a/cc.py
+++ b/cc.py
@@ -45,14 +45,14 @@ def crawlAll():
 		getData(index, '')
 
 #
-def crawlSpecific(year):
+def crawlSpecific(domain, year):
 	#index = indexes.get('y' + year)
 	print('[!] Processing year: ' + year)
 
 	for index in indexes:
 		if year in index:
 			print('[-] ' + index)
-			getData(index, '')
+			crawlIndex(domain, index)
 
 
 def crawlIndex(domain, index):
@@ -104,7 +104,7 @@ else:
 	if args.index:
 		crawlIndex(args.domain, args.index)
 	elif args.year:
-		crawlSpecific(args.year)
+		crawlSpecific(args.domain, args.year)
 	else:
 		crawlAll()
 


### PR DESCRIPTION
When there is more than one page of results crawlSpecific() currently only grabs the first page, this makes sure it processes all pages.